### PR TITLE
Add unit tests for LangChain RAG sample

### DIFF
--- a/tests/test_embeddings_loader.py
+++ b/tests/test_embeddings_loader.py
@@ -1,0 +1,56 @@
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+# Create dummy modules to satisfy imports
+loader_mock = MagicMock()
+loader_instance = loader_mock.TextLoader.return_value
+loader_instance.load.return_value = ["dummy doc"]
+
+splitter_mock = MagicMock()
+splitter_instance = splitter_mock.RecursiveCharacterTextSplitter.return_value
+splitter_instance.split_documents.return_value = ["chunk"]
+
+embed_mock = MagicMock()
+embed_instance = embed_mock.HuggingFaceEmbeddings.return_value
+
+chroma_mock = MagicMock()
+vectorstore_instance = chroma_mock.Chroma.from_documents.return_value
+
+
+def setup_module_mocks(monkeypatch):
+    loader_mod = types.ModuleType('langchain_community.document_loaders')
+    loader_mod.TextLoader = loader_mock.TextLoader
+    monkeypatch.setitem(sys.modules, 'langchain_community', types.ModuleType('langchain_community'))
+    monkeypatch.setitem(sys.modules, 'langchain_community.document_loaders', loader_mod)
+
+    splitter_mod = types.ModuleType('langchain.text_splitter')
+    splitter_mod.RecursiveCharacterTextSplitter = splitter_mock.RecursiveCharacterTextSplitter
+    monkeypatch.setitem(sys.modules, 'langchain', types.ModuleType('langchain'))
+    monkeypatch.setitem(sys.modules, 'langchain.text_splitter', splitter_mod)
+
+    embed_mod = types.ModuleType('langchain_community.embeddings')
+    embed_mod.HuggingFaceEmbeddings = embed_mock.HuggingFaceEmbeddings
+    monkeypatch.setitem(sys.modules, 'langchain_community.embeddings', embed_mod)
+
+    vector_mod = types.ModuleType('langchain_community.vectorstores')
+    vector_mod.Chroma = chroma_mock.Chroma
+    monkeypatch.setitem(sys.modules, 'langchain_community.vectorstores', vector_mod)
+
+
+def test_build_vector_store(monkeypatch):
+    setup_module_mocks(monkeypatch)
+    import embeddings_loader
+    importlib.reload(embeddings_loader)
+    embeddings_loader.build_vector_store()
+
+    loader_mock.TextLoader.assert_called_once()
+    loader_instance.load.assert_called_once()
+    splitter_mock.RecursiveCharacterTextSplitter.assert_called_once()
+    splitter_instance.split_documents.assert_called_once_with(["dummy doc"])
+    embed_mock.HuggingFaceEmbeddings.assert_called_once()
+    chroma_mock.Chroma.from_documents.assert_called_once()
+    vectorstore_instance.persist.assert_called_once()

--- a/tests/test_rag_qa.py
+++ b/tests/test_rag_qa.py
@@ -1,0 +1,62 @@
+import importlib
+import runpy
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+# Prepare mocks
+embed_mock = MagicMock()
+chroma_mock = MagicMock()
+llm_mock = MagicMock()
+qa_chain_mock = MagicMock()
+prompt_mock = MagicMock()
+
+qa_chain_instance = qa_chain_mock.from_chain_type.return_value
+
+
+def setup_module_mocks(monkeypatch):
+    monkeypatch.setitem(sys.modules, 'langchain_community', types.ModuleType('langchain_community'))
+
+    embed_mod = types.ModuleType('langchain_community.embeddings')
+    embed_mod.HuggingFaceEmbeddings = embed_mock.HuggingFaceEmbeddings
+    monkeypatch.setitem(sys.modules, 'langchain_community.embeddings', embed_mod)
+
+    vector_mod = types.ModuleType('langchain_community.vectorstores')
+    vector_mod.Chroma = chroma_mock.Chroma
+    monkeypatch.setitem(sys.modules, 'langchain_community.vectorstores', vector_mod)
+
+    llm_mod = types.ModuleType('langchain_community.llms')
+    llm_mod.GPT4All = llm_mock.GPT4All
+    monkeypatch.setitem(sys.modules, 'langchain_community.llms', llm_mod)
+
+    monkeypatch.setitem(sys.modules, 'langchain', types.ModuleType('langchain'))
+
+    chains_mod = types.ModuleType('langchain.chains')
+    chains_mod.RetrievalQA = qa_chain_mock
+    monkeypatch.setitem(sys.modules, 'langchain.chains', chains_mod)
+
+    prompt_mod = types.ModuleType('langchain.prompts')
+    prompt_mod.PromptTemplate = prompt_mock.PromptTemplate
+    monkeypatch.setitem(sys.modules, 'langchain.prompts', prompt_mod)
+
+    # PromptTemplate.from_template should return a simple string
+    prompt_mock.PromptTemplate.from_template.return_value = "prompt"
+    # vectorstore.as_retriever should return something simple
+    chroma_mock.Chroma.return_value.as_retriever.return_value = "retriever"
+
+
+def test_rag_qa_cli_exit(monkeypatch):
+    setup_module_mocks(monkeypatch)
+    monkeypatch.setitem(sys.modules, 'config', types.SimpleNamespace(MODEL_PATH='m', VECTOR_DB_DIR='d', EMBEDDING_MODEL_PATH='e'))
+
+    # Input 'exit' once to break the loop
+    monkeypatch.setattr('builtins.input', lambda _: 'exit')
+
+    runpy.run_module('rag_qa', run_name='rag_qa')
+
+    embed_mock.HuggingFaceEmbeddings.assert_called_once()
+    chroma_mock.Chroma.assert_called_once()
+    llm_mock.GPT4All.assert_called_once()
+    qa_chain_mock.from_chain_type.assert_called_once()


### PR DESCRIPTION
## Summary
- add pytest tests for embeddings_loader and rag_qa
- tests use mocks so they run without heavy dependencies

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849452b77ac832c98af3810faf7e2ff